### PR TITLE
Rename passport spec in README and AAI spec

### DIFF
--- a/AAI/AAIConnectProfile.md
+++ b/AAI/AAIConnectProfile.md
@@ -562,7 +562,7 @@ Payload:
 -   `scope`: REQUIRED. Includes verified scopes. MUST include "openid". Will also
     include any `<ga4gh-spec-scopes>` needed for the GA4GH compliant environment
     (e.g. "ga4gh_passport_v1" is the [scope for GA4GH
-    Passports](https://github.com/ga4gh-duri/ga4gh-duri.github.io/blob/master/researcher_ids/RI_Claims_V1.md#requirement-7)).
+    Passports](https://github.com/ga4gh-duri/ga4gh-duri.github.io/blob/master/researcher_ids/ga4gh_passport_v1.md#requirement-7)).
 
 #### Claims sent to Data Holder by a Broker via /userinfo
 
@@ -693,19 +693,23 @@ Issuer.
 
 #### Authorization/Claims 
 
-User attributes and claims are being developed in [GA4GH Researcher Identity
-Claims](https://github.com/ga4gh-duri/ga4gh-duri.github.io/blob/master/researcher_ids/RI_Claims_V1.md)
-document by the DURI work stream.
+User attributes and claims are being developed in the [GA4GH Passport
+specification](https://github.com/ga4gh-duri/ga4gh-duri.github.io/blob/master/researcher_ids/ga4gh_passport_v1.md)
+by the DURI work stream.
 
-A non-normative example of a GA4GH Researcher Identity Claim, as referred to
+A non-normative example of a GA4GH Passport, as referred to
 in as `<ga4gh-spec-claims>` within the JWT formatting sections of this
 specification, is:
 
 ```
-"ga4gh_passport_v1": {
-  <[ga4gh passport value](https://github.com/ga4gh-duri/ga4gh-duri.github.io/blob/master/researcher_ids/RI_Claims_V1.md)>
-}
+"ga4gh_passport_v1": [
+  <ga4gh passport value>
+]
 ```
+
+See the [GA4GH Passport
+Claim Format](https://github.com/ga4gh-duri/ga4gh-duri.github.io/blob/master/researcher_ids/ga4gh_passport_v1.md#passport-claim-format)
+for more details.
 
 Token Revocation
 ----------------

--- a/AAI/README.md
+++ b/AAI/README.md
@@ -3,7 +3,7 @@
 ## Quick Links
 
 - Specification: [GA4GH Authentication and Authorization Infrastructure (AAI) OpenID Connect Profile](https://github.com/ga4gh/data-security/blob/master/AAI/AAIConnectProfile.md)
-- Other specifications that use the AAI profile: [GA4GH RI Claims](https://bit.ly/ga4gh-ri-v1)
+- Other specifications that use the AAI profile: [GA4GH Passport](https://bit.ly/ga4gh-passport-v1)
 
 ### Table of Contents
 


### PR DESCRIPTION
Update links as well since filename for passport spec has changed.