### PR TITLE
verifiable consent of visa usage

### DIFF
--- a/AAI/AAIConnectProfile.md
+++ b/AAI/AAIConnectProfile.md
@@ -396,6 +396,10 @@ the Broker.
     presented and/or transformed without misrepresenting the original intent,
     except for accommodating for `exp` timestamps to be represented as
     indicated above.
+    
+3.  An Embedded Token Issuer MAY include the `aud` field to indicate which
+    [Brokers](#term-broker) were consented by the user. The values within the `aud`
+    field must match the `iss` field of OIDC access tokens issued by consented Brokers.
 
 #### Conformance for Claim Clearinghouses (consuming Access Tokens to give access to data)
 
@@ -426,6 +430,8 @@ the Broker.
                 any other Broker involved in the propagation of the claims to
                 also be trusted if the Claim Clearinghouse needs to restrict its
                 trust model).
+            2.  If Embedded Token contains `aud` field, Clearinghouse MUST check
+                that the Embedded Token's `aud` contains `iss` of access token provided by Broker.
 
         3.  MUST check `exp` to ensure the token has not expired.
 
@@ -628,6 +634,8 @@ where:
 
 2.  The header MUST NOT contain a `jku`.
 
+3. JWT payload MAY contain `aud` to list approved brokers.
+
 Payload format:
 
 ```
@@ -701,6 +709,8 @@ Issuer.
    -   `<ga4gh-spec-claims>`: OPTIONAL. One or more GA4GH Claims MAY be
        provided. See [Authorization/Claims](#authorizationclaims) for an
        example.
+       
+   - MAY contain `aud` to list approved brokers
 
 #### Authorization/Claims 
 

--- a/AAI/AAIConnectProfile.md
+++ b/AAI/AAIConnectProfile.md
@@ -4,6 +4,7 @@
 
 | Version | Date    | Editor                                     | Notes                   |
 |---------|---------|--------------------------------------------|-------------------------|
+| 1.0.2   | 2020-02 | Douglas Voet                               | Add audiences to embedded tokens |
 | 1.0.1   | 2019-10 | David Bernick                              | Clarify that non-GA4GH claims are allowed in tokens |
 | 1.0.0   | 2019-10 | Approved by GA4GH Steering Committee       |                         |
 | 0.9.9   | 2019-10 | David Bernick, Craig Voisin, Mikael Linden | Approved standard       |

--- a/AAI/AAIConnectProfile.md
+++ b/AAI/AAIConnectProfile.md
@@ -398,11 +398,11 @@ the Broker.
     except for accommodating for `exp` timestamps to be represented as
     indicated above.
     
-3.  An Embedded Token Issuer MAY include the `aud` field to identify the 
+3.  An Embedded Token Issuer MAY include the `aud` claim to identify the 
     [Brokers](#term-broker) as the intended audience as specified by 
     [RFC 7523 Section 3](https://tools.ietf.org/html/rfc7523#section-3).
-    The values within the `aud` field must match the `iss` field of access tokens 
-    issued by consented Brokers.
+    When an `aud` claim is specified, the values within the `aud` claim MUST 
+    match the `iss` claim of access tokens issued by consented Brokers.
 
 #### Conformance for Claim Clearinghouses (consuming Access Tokens to give access to data)
 
@@ -433,7 +433,7 @@ the Broker.
                 any other Broker involved in the propagation of the claims to
                 also be trusted if the Claim Clearinghouse needs to restrict its
                 trust model).
-            2.  If an Embedded Token contains an `aud` field, Clearinghouse MUST check
+            2.  If an Embedded Token contains an `aud` claim, Clearinghouse MUST check
                 that one of the Embedded Token's `aud` entries 
                 [matches](https://tools.ietf.org/html/rfc3986#section-6.2.1) the Broker's 
                 `iss` claim (i.e. a Broker's access token `iss` claim must match the `aud`

--- a/AAI/AAIConnectProfile.md
+++ b/AAI/AAIConnectProfile.md
@@ -398,9 +398,11 @@ the Broker.
     except for accommodating for `exp` timestamps to be represented as
     indicated above.
     
-3.  An Embedded Token Issuer MAY include the `aud` field to indicate which
-    [Brokers](#term-broker) were consented by the user. The values within the `aud`
-    field must match the `iss` field of OIDC access tokens issued by consented Brokers.
+3.  An Embedded Token Issuer MAY include the `aud` field to identify the 
+    [Brokers](#term-broker) as the intended audience as specified by 
+    [RFC 7523 Section 3](https://tools.ietf.org/html/rfc7523#section-3).
+    The values within the `aud` field must match the `iss` field of access tokens 
+    issued by consented Brokers.
 
 #### Conformance for Claim Clearinghouses (consuming Access Tokens to give access to data)
 
@@ -431,8 +433,11 @@ the Broker.
                 any other Broker involved in the propagation of the claims to
                 also be trusted if the Claim Clearinghouse needs to restrict its
                 trust model).
-            2.  If Embedded Token contains `aud` field, Clearinghouse MUST check
-                that the Embedded Token's `aud` contains `iss` of access token provided by Broker.
+            2.  If an Embedded Token contains an `aud` field, Clearinghouse MUST check
+                that one of the Embedded Token's `aud` entries 
+                [matches](https://tools.ietf.org/html/rfc3986#section-6.2.1) the Broker's 
+                `iss` claim (i.e. a Broker's access token `iss` claim must match the `aud`
+                claim within its Embedded Tokens if the Embedded Token aud claim is provided).
 
         3.  MUST check `exp` to ensure the token has not expired.
 
@@ -635,8 +640,6 @@ where:
 
 2.  The header MUST NOT contain a `jku`.
 
-3. JWT payload MAY contain `aud` to list approved brokers.
-
 Payload format:
 
 ```
@@ -664,7 +667,7 @@ where:
 4.  The payload claims MAY contain at least one GA4GH Claim
     (`<ga4gh-spec-claims>`).
 
-5.  The payload claims MUST NOT include `aud`.
+5.  The payload claims MAY include `aud` to list approved brokers
 
 ##### Embedded Document Token Format
 
@@ -711,7 +714,7 @@ Issuer.
        provided. See [Authorization/Claims](#authorizationclaims) for an
        example.
        
-   - MAY contain `aud` to list approved brokers
+   -   MAY contain `aud` to list approved brokers
 
 #### Authorization/Claims 
 


### PR DESCRIPTION
When considering implementation of the AAI spec, we have a concern that there is no way for a clearinghouse to verify that the user has consented to allow a visa to be used by a broker. As the spec currently stands users who trust a Broker A effectively must trust all other brokers that Broker A trusts and so on down the trust chain. The user has no visibility into or mechanism to limit this.

This addition to the spec hopes to achieve this by adding audiences to Embedded Access Tokens or Embedded Document Tokens. Users can consent to a list of brokers when the tokens are generated. If the audience field does not exist then there is no restriction. How the token issuer knows what list to present to the user is unspecified.

Example embedded access token payload:
```
{
 "iss": "https://<embedded-token-issuer-website>/",
 "sub": "<subject-identifier>",
 "aud": [
  "https://<consented-broker1-website>/",
  "https://<consented-broker2-website>/" ...
 ],
 "iat": <seconds-since-epoch>,
 "exp": <seconds-since-epoch>,
 "jti": <token-identifier>,
 "scope": "openid <ga4gh-spec-scopes>",
}
```

Example access token issued by broker to clearinghouse:
```
{
 "iss": "https://<consented-broker1-website>/",
 "sub": "<subject-identifier>",
 "iat": <seconds-since-epoch>,
 "exp": <seconds-since-epoch>,
 "jti": <token-identifier>,
 "scope": "openid <ga4gh-spec-scopes>",
}
```
In this example, the clearinghouse MUST verify that the `aud` field in the embedded access token payload contains the `iss` field of the broker access token.