### PR TITLE
DO NOT MERGE: Adding Token Containers definition

### DIFF
--- a/AAI/AAIConnectProfile.md
+++ b/AAI/AAIConnectProfile.md
@@ -421,7 +421,7 @@ the Broker.
     
     1. It is RECOMMENDED for Token Containers to conform to the <https://tools.ietf.org/html/rfc7515> (JWS) Specification.  
     
-4.  Token Containers MAY be issued from a `/token` endpoint that, when presented with a valid access token, presents a signed JWT with the embedded tokens as opposed to deriving it directly from `/userinfo`.  This endpoint should act in the same way as a `/userinfo` endpoint, however it simply guarantees a return in a signed JWT format.
+4.  Token Containers MAY be issued from a `/aai/token` endpoint that, when presented with a valid access token, presents a signed JWT with the embedded tokens as opposed to deriving it directly from `/userinfo`.  This endpoint should act in the same way as a `/userinfo` endpoint, however it simply guarantees a return in a signed JWT format.
     
 
 #### Conformance for Claim Clearinghouses (consuming Access Tokens or Token Containers to give access to data)
@@ -610,18 +610,18 @@ Payload:
 
 -   `addtional claims`: OPTIONAL. Any other additional non-GA4GH claims are allowed. This specification does not dictate the format of other claims.
 
-#### Claims sent to Data Holder by a Broker via `/userinfo` (and `/token` if using)
+#### Claims sent to Data Holder by a Broker via `/userinfo` (and `/aai/token` if using)
 
 Only the GA4GH claims truly must be as prescribed here. Refer to OIDC Spec for
 more information. The /userinfo endpoint MAY use `application/json` or
-`application/jwt`.  It is RECOMMENDED that if desiring to return a JWT, a `/token` exists to do that and `/userinfo` returns a general blob.   
+`application/jwt`.  It is RECOMMENDED that if desiring to return a JWT, a `/aai/token` exists to do that and `/userinfo` returns a general blob.   
 
 If `application/jwt` is returned, it MUST be signed as per
 [UserInfo](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse).  
 
 If this is a JWT, it MAY be used as a Token Container.  
 
-If this information is a JWT, especially from the recommended `/token` endpoint, the JWT should include additional attributes.
+If this information is a JWT, especially from the recommended `/aai/token` endpoint, the JWT should include additional attributes.
 
 ```
 {

--- a/AAI/AAIConnectProfile.md
+++ b/AAI/AAIConnectProfile.md
@@ -140,14 +140,16 @@ may be:
 * a Broker may use this service as part of collecting GA4GH Claims that the Broker includes in responses from its /userinfo endpoint.
 
 <a name="term-token-container-issuer"></a> **Token Container Issuer** --
-a service that creates and signs a container - in this case a JWT - holding [Embedded Tokens](#term-embedded-token).
-* a stand-alone service where a Broker, Client or Claims Clearinghouse may re-sign the JWT holding GA4GH Claims (such as [GA4GH Visas](https://github.com/ga4gh-duri/ga4gh-duri.github.io/blob/master/researcher_ids/ga4gh_passport_v1.md#passport-visa)) with their own authority.
+a service that creates and signs a [Token Container](#term-token-container) - in this case a JWT - holding [Embedded Tokens](#term-embedded-token).
+* a service where a Broker, Client or Claims Clearinghouse may re-sign the JWT holding GA4GH Claims (such as [GA4GH Visas](https://github.com/ga4gh-duri/ga4gh-duri.github.io/blob/master/researcher_ids/ga4gh_passport_v1.md#passport-visa)) with their own authority.
 
 <a name="term-embedded-token"></a> **Embedded Token** -- A GA4GH Claim value
 or entry within a list or object of a GA4GH Claim that contains a JWS string.
 It MUST be signed by an [Embedded Token Issuer](#term-embedded-token-issuer).
 An Embedded Token can pass [GA4GH Claims](#term-ga4gh-claim) through various Brokers as needed
 while retaining the token signature of the original Embedded Token Issuer.
+
+<a name="term-token-container"></a> **Token Container** -- A signed and verifiable JWT container for holding [Embedded Tokens](#term-embedded-token).
 
 ### Relevant Specifications
 
@@ -299,8 +301,8 @@ the Broker.
     3.  A user's withdrawal of this agreement does not need to apply to
         previously generated access tokens.
 
-6.  By signing an access token, an Broker asserts that the GA4GH Claims that
-    token makes available at the /userinfo endpoint -- not including any
+6.  <a name="broker-signing"></a>By signing an access token, an Broker asserts that the GA4GH Claims that
+    token makes available at the `/userinfo` endpoint -- not including any
     Embedded Tokens -- were legitimately derived from their [Claim
     Sources](#term-claim-source), and the content is presented and/or
     transformed without misrepresenting the original intent.
@@ -411,7 +413,9 @@ the Broker.
 
 2.  Token Container Issuers do not need to be a be a OIDC provider, and MAY provide a .well-known endpoint that doesn't conform to the OIDC Discovery specification for ease of finding signing keys.  
 
-    1. Token Container Issuers MAY be AAI Clients, Clearinghouses or Brokers.
+    1. Token Container Issuers MAY be AAI Clients, Clearinghouses, Brokers or any other entity and do not need to be part of the OIDC flow.  
+    
+    2. Token Containers should be [signed](#broker-signing) in the same way that Brokers sign access tokens.
 
 3.  Token Containers themselves are JWTs that contain Embedded Tokens. Token Containers use this format [User Info Format](#claims-sent-to-data-holder-by-a-broker-via-userinfo) as a signed JWT.  
     


### PR DESCRIPTION
Hi all -- This is my first pass -- and sort of a RFC -- on more clearly defining Passports from an AAI perspective based on real-world implementations. 

Namely the gap of "What is a Passport"? Previous to this, I always thought about it in terms of the Access Token and the /userinfo response, but as this gets more and more used, we are starting to think about it differently. My original vision was that the Access Token was sort of "half" of the passport and when used against /userinfo, that was the rest of it. But I think we have learned alot in the year. 

So here I introduce something called Token Containers -- that being a JWT that represents the Passport that CAN be passed downstream to applications and Claim Clearinghouses alike. So now the Access Token, in this model, is still used to access a broker's /userinfo to get claims, including GA4GH Visas. None of that has changed. 

What has been added is that Embedded Tokens (Visas) can be bundled up explicitly in objects called Token Containers (Passports). These objects can be gotten from brokers via /userinfo in the GA4GH Claims (no change other than to name the top level object) but can also be constructed without a Broker and passed on. Also changed is explicitly allowing downstream services to process this Token Container -- which wasn't clear before -- outside of an OIDC flow. 

This PR is not meant to land in this state. This is to demonstrate language clarifications and concepts but I DO think it helps clarify "what is a Passport" and more tightly binds AAI and Passport as that seems to be a gap. I understand there might be a proposed `/token` endpoint and that's great -- we still need a name for this top-level JWT full of embedded JWTs, so I'm proposing Token Containers with much of the same ideas as proposed here. 

I do not address Polling in this.

Let me know what you think!