### PR TITLE
The version history table is extremely distracting

### DIFF
--- a/AAI/AAIConnectProfile.md
+++ b/AAI/AAIConnectProfile.md
@@ -3,6 +3,8 @@ layout: page
 permalink: aai-openid-connect-profile
 ---
 
+<details><summary>Open to view version history</summary>
+       
 | Version | Date    | Editor                                     | Notes                   |
 |---------|---------|--------------------------------------------|-------------------------|
 | 1.0.4   | 2021-07 | Craig Voisin                               | Improve existing terminology and define Passport and Visa JWTs |
@@ -17,6 +19,7 @@ permalink: aai-openid-connect-profile
 | 0.9.2   | 2019-07 | David Bernick                              | Made changes based on feedback from review |
 | 0.9.1   | 2019-06 | Craig Voisin                               | Added terminology links |
 | 0.9.0   | 2017-   | Mikael Linden, Craig Voisin, David Bernick | Initial working version |
+</details>
 
 ### Abstract
 

--- a/AAI/AAIConnectProfile.md
+++ b/AAI/AAIConnectProfile.md
@@ -3,6 +3,7 @@ layout: page
 permalink: aai-openid-connect-profile
 ---
 
+#### Version 1.0.4
 <details><summary>Open to view version history</summary>
        
 | Version | Date    | Editor                                     | Notes                   |


### PR DESCRIPTION
I just want to get to the meet. I don't care about the version history. I know this is very important to those who need it, but for those people, it's just a click away.