### PR TITLE
Simplify Intro + Add All Sections to Header Links

### DIFF
--- a/AAI/AAIConnectProfile.md
+++ b/AAI/AAIConnectProfile.md
@@ -86,7 +86,7 @@ Clearinghouse may act like a resource server). Some Passport Clearinghouses may
 issue Passports that contain a new set or subset of Visas for downstream consumption.
 
 <a name="term-data-holder"></a> **Data Holder** -- An organization that
-protects a specific set of data. They hold data (or its copy) and respects
+holds a specific set of data (or its copy) and respects
 and enforces the data controller's decisions on who can access it. A data controller
 can also be a data holder. Data holders run a
 [Passport Clearinghouse Server](#term-passport-clearinghouse) at a minimum.

--- a/AAI/README.md
+++ b/AAI/README.md
@@ -33,22 +33,44 @@ assumes that GA4GH Claims provided by Brokers described in this document
 MAY conform to the DURI researcher-identity policy and standard. This standard
 does NOT assume that DURI's GA4GH Claims will be the only ones used.
 
+#### Technical Summary
+
+At its core, the AAI specification defines cryptographically secure tokens for exchanging
+researcher attributes called [Visas](aai-openid-connect-profile#term-visa), and how various
+participants can interact to authenticate researchers, and obtain and validate visas.
+
+The main components identified in the specification are:
+* [Visa Issuers](aai-openid-connect-profile#term-visa-issuer), that cryptographically sign researcher attributes in the
+form of visas.
+* [Brokers](aai-openid-connect-profile#term-broker), that authenticate researchers and broker access to visas associated
+with researchers.
+* [Passport Clearinghouses](aai-openid-connect-profile#term-passport-clearinghouse), that accept tokens containing or
+otherwise availing researcher visas for the purposes of enforcing access control.
+
+#### Visa Tokens
+
+The recommended approach to using AAI involves signed-JWTs called Visas,
+for securely transmitting authorizations or attributes of a researcher.
+Visas are signed by the Visa Issuer, which may be a service other than
+the Broker. Using JWTs signed by private key, allows Clearinghouses to
+validate Visas from known issuers in situations where they may not have
+network connections to the issuers.
+
 #### Separation of Data Holders and Data Controllers
 
 It is a fairly common situation that, for a single dataset, the
 [data controller](aai-openid-connect-profile#term-data-controller)
 (the authority managing who has access to dataset) is not the same party as the 
 [data holder](aai-openid-connect-profile#term-data-holder) (the organization
-enforcing access based on the policies of the data controller).
+that hosts the data, while respecting the data controller's access policies).
 
 For these situations, AAI is a standard mechanism for data holders to obtain
-and validate authorizations from data controllers.
+and validate authorizations from data controllers, by specifying the interactions
+between Visa Issuers, Brokers, and Clearinghouses.
 
 The AAI standard enables data holders' and data controllers' systems to recognize
 and accept identities from multiple Brokers --- allowing for an even more federated
-approach.
-
-An organization can still use this specification with a single Broker and Visa Issuer,
+approach. An organization can still use this specification with a single Broker and Visa Issuer,
 though they may find in that case that there are few benefits beyond standard OIDC.
 
 ### Background
@@ -58,17 +80,9 @@ though they may find in that case that there are few benefits beyond standard OI
 We have found that there are widely used Identity Providers (IdP) such as Google
 Authentication. These authentication mechanisms provide no authorization
 information (custom claims or scopes) but are so pervasive at the institution
-level that they cannot be ignored. The use of a "broker" and "clearinghouse"
+level that they cannot be ignored. The use of a Broker and Clearinghouse
 enables attaching information to the usual OIDC flow so that Google and other
 prominent identity providers can be used with customized claims and scopes.
-
-We have also found that some brokers, such as ELIXIR for example, provide
-useful "extra" claims on top of IdPs like Google, but institutions
-receiving ELIXIR claims might have cause to add even more claims.
-
-The Broker model is flexible enough to accommodate this kind of "chaining"
-(where one broker relies on and enriches the identity of another), provided
-that Visa assertions are always signed-by the original asserting authority.
 
 Here is a diagram of a single broker. This is one possible way to use this spec.
 
@@ -76,29 +90,18 @@ Here is a diagram of a single broker. This is one possible way to use this spec.
 skinparam componentStyle rectangle
 left to right direction
 
-package "Unspecified clients, additional services, protocols" {
-component "<b>Visa Assertion Source</b> (1)\norganisation" as VisaSource1
-component "<b>Visa Assertion Source</b> (2)\norganisation" as VisaSource2
-component "<b>Visa Assertion Source</b> (...)\norganisation" as VisaSourceN
+component "<b>Visa Issuer 1</b>\nservice" as Issuer1
+component "<b>Visa Issuer 2</b>\nservice" as Issuer2
+component "<b>Visa Issuer N</b>\nservice" as IssuerN
 
-database "<b>Visa Assertion Repository</b>\nabstract service" as VisaRepository
-component "<b>Visa Issuer</b>\nabstract service\n(optional)" as ETI
-}
-
-package "Specified GA4GH AAI clients, services, protocols" {
 component "<b>Broker</b>\nservice" as Broker #FAFAD2
 component "<b>Passport Clearinghouse</b>\nservice" as ClearingHouse #9E7BB5
-}
 
-VisaSource1 --> VisaRepository : (unspecified)
-VisaSource2 --> VisaRepository : (unspecified)
-VisaSourceN --> VisaRepository : (unspecified)
-VisaRepository --> ETI : (unspecified)
-
-
-VisaRepository --> Broker : (unspecified)
-ETI --> Broker : (unspecified)
-Broker --> ClearingHouse : GA4GH AAI spec
+Issuer1 <-- Broker : Fetch Visas
+Issuer2 <-- Broker : Fetch Visas
+IssuerN <-- Broker : Fetch Visas
+Broker <-- ClearingHouse : Request User Visas w/ Access Token
+IssuerN <-- ClearingHouse : Request Public Key w/ JWKS
 
 @enduml
 
@@ -109,16 +112,5 @@ access in the Clearinghouse system.
 
 The Broker, Clearinghouse, and Visa Issuer may be separate services (as shown
 in this diagram), but in other configurations they may be run as parts of a single
-service, or as separate services run by single organization.
-
-Data holders and data controllers should explore their options to decide what best
-fits their needs.
-
-#### Visa Tokens Explanation
-
-The recommended approach to using AAI involves signed-JWTs called Visas,
-for securely transmitting authorizations or attributes of a researcher.
-Visas are signed by the Visa Issuer, which may be a service other than
-the Broker. Using JWTs signed by private key, allows Clearinghouses to
-validate Visas from known issuers in situations where they may not have
-network connections to the issuers.
+service, or as separate services run by single organization. Data holders and data
+controllers should explore their options to decide what best fits their needs.

--- a/AAI/README.md
+++ b/AAI/README.md
@@ -101,7 +101,6 @@ Issuer1 <-- Broker : Fetch Visas
 Issuer2 <-- Broker : Fetch Visas
 IssuerN <-- Broker : Fetch Visas
 Broker <-- ClearingHouse : Request User Visas w/ Access Token
-IssuerN <-- ClearingHouse : Request Public Key w/ JWKS
 
 @enduml
 

--- a/AAI/README.md
+++ b/AAI/README.md
@@ -80,7 +80,7 @@ though they may find in that case that there are few benefits beyond standard OI
 We have found that there are widely used Identity Providers (IdP) such as Google
 Authentication. These authentication mechanisms provide no authorization
 information (custom claims or scopes) but are ubiquitous for authentication at the institution level.
-level that they cannot be ignored. The use of a Broker and Clearinghouse
+The use of a Broker and Clearinghouse
 enables attaching information to the usual OIDC flow so that Google and other
 prominent identity providers can be used with customized claims and scopes.
 

--- a/AAI/README.md
+++ b/AAI/README.md
@@ -79,7 +79,7 @@ though they may find in that case that there are few benefits beyond standard OI
 
 We have found that there are widely used Identity Providers (IdP) such as Google
 Authentication. These authentication mechanisms provide no authorization
-information (custom claims or scopes) but are so pervasive at the institution
+information (custom claims or scopes) but are ubiquitous for authentication at the institution level.
 level that they cannot be ignored. The use of a Broker and Clearinghouse
 enables attaching information to the usual OIDC flow so that Google and other
 prominent identity providers can be used with customized claims and scopes.

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,8 @@ kramdown:
 header_pages:
   - AAI/README.md
   - AAI/AAIConnectProfile.md
+  - AAI/FAQ.md
+  - AAI/CHANGES_1.2.md
 
 # Due to the way we publish to github pages - it is useful that Jekyll keeps any .git in the destination around
 keep_files: [.git]


### PR DESCRIPTION
I've added all the sections (FAQ, Changelog) to the header links and taken a pass at reworking the introduction. In particular:
* Change "data owner" to "data controller"
* Cut out a lot of stuff on broker chaining and the different kinds of embedded tokens
* Add section on how Visas standardize communication between data holders and data controllers (as motivation)
* Cut out the old broker example diagram that seemed like too much for an introduction, and use the simpler plant UML diagram from the spec